### PR TITLE
Improve desktop roster scroll performance

### DIFF
--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -864,6 +864,28 @@
             border-radius: 8px;                   /* match header */
         }
 
+@media (min-width: 1024px) {
+  body[data-page="rosters"] .roster-column {
+    /* Isolate each column so the browser can paint it independently */
+    contain: layout paint;
+  }
+}
+
+@media (min-width: 1024px) {
+  @supports (content-visibility: auto) {
+    body[data-page="rosters"] .roster-section .player-row,
+    body[data-page="rosters"] .roster-section .pick-row {
+      /* Avoid painting long columns of cards until they scroll into view */
+      content-visibility: auto;
+      contain-intrinsic-size: auto 68px;
+    }
+
+    body[data-page="rosters"] .roster-section .pick-row {
+      contain-intrinsic-size: auto 44px;
+    }
+  }
+}
+
 /* ⬇︎  ENTIRE COLUMN GLOW  ⬇︎ */
 .roster-column:has(.team-compare-checkbox.selected) {
     box-shadow: inset 0 0 2px #6300ff55, inset 0 0 38px #5300ff35;          /* same highlight as header */


### PR DESCRIPTION
## Summary
- isolate roster columns on desktop so the browser can paint them independently
- defer painting of off-screen player and pick rows on large screens to reduce scroll jank

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e12544bd8c832ea028f6592486342d