### PR TITLE
Improve desktop roster scrolling performance

### DIFF
--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -913,6 +913,17 @@
   }
 }
 
+@media (min-width: 820px) {
+  @supports (content-visibility: auto) {
+    .roster-column .player-row,
+    .roster-column .pick-row {
+      content-visibility: auto;
+      contain: layout paint;
+      contain-intrinsic-size: auto 88px;
+    }
+  }
+}
+
         .roster-section h3 {
       font-size: 0.8rem;
       font-weight: 700;


### PR DESCRIPTION
## Summary
- enable content-visibility optimizations for roster player and pick rows on larger screens
- provide intrinsic sizing hints to keep layout stable while offscreen content is skipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12544bd8c832ea028f6592486342d