### PR TITLE
Disable sticky roster headers on desktop

### DIFF
--- a/DH_P2.53/scripts/app.js
+++ b/DH_P2.53/scripts/app.js
@@ -4030,7 +4030,12 @@ const wrTeStatOrder = [
 
             const teamHeaders = document.querySelectorAll('.team-header-item');
             teamHeaders.forEach(header => {
-                header.style.top = `${stickyOffset}px`;
+                const computedPosition = getComputedStyle(header).position;
+                if (computedPosition === 'sticky') {
+                    header.style.top = `${stickyOffset}px`;
+                } else {
+                    header.style.top = '';
+                }
             });
 
             const isRosterPage = document.body?.dataset?.page === 'rosters';

--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -913,6 +913,13 @@
   }
 }
 
+@media (min-width: 820px) {
+  .team-header-item {
+      position: static;
+      top: auto;
+  }
+}
+
         .roster-section h3 {
       font-size: 0.8rem;
       font-weight: 700;


### PR DESCRIPTION
## Summary
- stop applying sticky positioning to roster team headers on desktop viewports to reduce scroll lag
- ensure the sticky header adjustment logic only assigns offsets when the headers are sticky

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e144ee0f4c832e912d04b5e6bbd951