### PR TITLE
Disable desktop sticky roster headers

### DIFF
--- a/DH_P2.53/scripts/app.js
+++ b/DH_P2.53/scripts/app.js
@@ -4029,8 +4029,13 @@ const wrTeStatOrder = [
             const stickyOffset = Math.max(headerHeight - rosterGap, 0);
 
             const teamHeaders = document.querySelectorAll('.team-header-item');
+            const isDesktopLayout = window.matchMedia('(min-width: 820px)').matches;
             teamHeaders.forEach(header => {
-                header.style.top = `${stickyOffset}px`;
+                if (isDesktopLayout) {
+                    header.style.top = '';
+                } else {
+                    header.style.top = `${stickyOffset}px`;
+                }
             });
 
             const isRosterPage = document.body?.dataset?.page === 'rosters';

--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -888,8 +888,8 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-      position: sticky;
-      z-index: 1;
+      position: static;
+      z-index: auto;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
@@ -910,6 +910,13 @@
         content-visibility: auto;
         contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
     }
+  }
+}
+
+@media (max-width: 819px) {
+  .team-header-item {
+      position: sticky;
+      z-index: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- disable sticky positioning for roster team headers on desktop layouts
- scope sticky behavior to mobile-only styles and avoid desktop-specific JS offsets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e144ee0f4c832e912d04b5e6bbd951