### PR TITLE
Ensure roster cards render immediately on desktop

### DIFF
--- a/DH_P2.53/scripts/app.js
+++ b/DH_P2.53/scripts/app.js
@@ -3060,6 +3060,12 @@ const wrTeStatOrder = [
 
         function calibrateTeamCardIntrinsicSize(card) {
             if (!supportsContentVisibility || !card) return;
+
+            const computedVisibility = window.getComputedStyle(card).getPropertyValue('content-visibility');
+            if (computedVisibility !== 'auto') {
+                return;
+            }
+
             requestAnimationFrame(() => {
                 const measuredHeight = card.getBoundingClientRect().height;
                 if (measuredHeight > 0) {

--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -902,14 +902,20 @@
             display: flex;
             flex-direction: column;
             gap: 0.25rem;
+            position: relative;
         }
 
 @media (min-width: 820px) {
-  @supports (content-visibility: auto) {
-    #rosterGrid .team-card {
-        content-visibility: auto;
-        contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
-    }
+  .team-card {
+      backdrop-filter: blur(1px);
+      -webkit-backdrop-filter: blur(1px);
+      contain: layout paint;
+  }
+
+  .player-row,
+  .pick-row {
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the desktop content-visibility virtualization so roster team cards paint immediately instead of popping in late
- guard the intrinsic size calibration to only run when content-visibility is active and add layout containment for desktop cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e144ee0f4c832e912d04b5e6bbd951