### PR TITLE
Restore roster header stickiness and ease desktop blurs

### DIFF
--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -902,14 +902,25 @@
             display: flex;
             flex-direction: column;
             gap: 0.25rem;
+            position: relative;
         }
 
 @media (min-width: 820px) {
-  @supports (content-visibility: auto) {
-    #rosterGrid .team-card {
-        content-visibility: auto;
-        contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
-    }
+  #rosterGrid .team-card {
+      contain: layout paint;
+  }
+}
+
+@media (min-width: 820px) {
+  .team-card {
+      backdrop-filter: blur(1px);
+      -webkit-backdrop-filter: blur(1px);
+  }
+
+  .player-row,
+  .pick-row {
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- re-enable sticky roster team headers across breakpoints so desktop matches the original behavior
- move the glass blur work from every player row to the shared team card on desktop to cut repaint cost while keeping mobile visuals intact
- replace the desktop team card content-visibility optimization with layout/paint containment so cards are fully rendered as you scroll

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e144ee0f4c832e912d04b5e6bbd951