### PR TITLE
Improve roster desktop scrolling performance

### DIFF
--- a/DH_P2.53/scripts/app.js
+++ b/DH_P2.53/scripts/app.js
@@ -16,6 +16,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const playerListView = document.getElementById('playerListView');
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
+        const rosterContentVisibilityQuery = (typeof window !== 'undefined' && typeof window.matchMedia === 'function')
+            ? window.matchMedia('(max-width: 819px)')
+            : null;
+        let rosterContentVisibilityEnabled = false;
         const compareButton = document.getElementById('compareButton');
         const compareSearchToggle  = document.getElementById('compareSearchToggle');
         const compareSearchPopover = document.getElementById('compareSearchPopover');
@@ -49,6 +53,29 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const supportsContentVisibility = typeof CSS !== 'undefined'
             && typeof CSS.supports === 'function'
             && CSS.supports('content-visibility', 'auto');
+
+        function updateRosterContentVisibility() {
+            if (!supportsContentVisibility || !rosterGrid) {
+                rosterContentVisibilityEnabled = false;
+                rosterGrid?.classList.remove('roster-cv-enabled');
+                return;
+            }
+            const shouldEnable = rosterContentVisibilityQuery ? rosterContentVisibilityQuery.matches : false;
+            rosterContentVisibilityEnabled = shouldEnable;
+            rosterGrid.classList.toggle('roster-cv-enabled', shouldEnable);
+        }
+
+        if (supportsContentVisibility) {
+            updateRosterContentVisibility();
+            if (rosterContentVisibilityQuery) {
+                const cvListener = () => updateRosterContentVisibility();
+                if (typeof rosterContentVisibilityQuery.addEventListener === 'function') {
+                    rosterContentVisibilityQuery.addEventListener('change', cvListener);
+                } else if (typeof rosterContentVisibilityQuery.addListener === 'function') {
+                    rosterContentVisibilityQuery.addListener(cvListener);
+                }
+            }
+        }
 
         const COMPARE_BUTTON_PREVIEW_HTML = '<span class="button-text">Preview</span>';
         const COMPARE_BUTTON_SHOW_ALL_HTML = '<span class="compare-show-all-stack"><i aria-hidden="true" class="fa-solid fa-arrows-left-right-to-line compare-show-all-icon"></i><span class="compare-show-all-label">Show All</span></span>';
@@ -3059,7 +3086,7 @@ const wrTeStatOrder = [
         }
 
         function calibrateTeamCardIntrinsicSize(card) {
-            if (!supportsContentVisibility || !card) return;
+            if (!supportsContentVisibility || !rosterContentVisibilityEnabled || !card) return;
             requestAnimationFrame(() => {
                 const measuredHeight = card.getBoundingClientRect().height;
                 if (measuredHeight > 0) {
@@ -3069,6 +3096,7 @@ const wrTeStatOrder = [
         }
 
         function renderAllTeamData(teams) {
+            updateRosterContentVisibility();
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
 

--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -6,6 +6,7 @@
         --color-bg: #0D0E1B;
         --color-bg-light: #1E1F30;
         --color-panel-bg: rgba(22, 24, 43, 0.1);
+        --roster-card-blur: 1px;
         --color-panel-border: rgba(128, 138, 189, 0.2);
         --color-panel-border-glow: rgba(128, 138, 189, 0.4);
     
@@ -904,12 +905,10 @@
             gap: 0.25rem;
         }
 
-@media (min-width: 820px) {
-  @supports (content-visibility: auto) {
-    #rosterGrid .team-card {
-        content-visibility: auto;
-        contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
-    }
+@supports (content-visibility: auto) {
+  #rosterGrid.roster-cv-enabled .team-card {
+      content-visibility: auto;
+      contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
   }
 }
 
@@ -988,10 +987,20 @@
             flex-direction: column;
             gap: 0.01rem;
             transition: all 0.2s ease;
-            backdrop-filter: blur(1px);
-            -webkit-backdrop-filter: blur(1px);
+            backdrop-filter: blur(var(--roster-card-blur));
+            -webkit-backdrop-filter: blur(var(--roster-card-blur));
             box-shadow: 0 0 20px rgba(0,0,0,0.1);
         }
+
+@media (min-width: 820px) {
+  .player-row,
+  .pick-row {
+      --roster-card-blur: 0px;
+      background: rgba(22, 24, 43, 0.35);
+      box-shadow: 0 12px 28px rgba(7, 10, 25, 0.32);
+      contain: paint;
+  }
+}
         .is-trade-mode .player-row, .is-trade-mode .pick-row { 
             cursor: pointer; 
         }


### PR DESCRIPTION
## Summary
- gate content-visibility virtualization behind a mobile-only flag and skip intrinsic size calibration on desktop
- tune roster card styling to remove heavy backdrop blur on wide screens while containing paint work for smoother scrolling

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e149ca65ec832ea436f9d9bf459bb9