### PR TITLE
Improve roster desktop scroll performance

### DIFF
--- a/DH_P2.53/scripts/app.js
+++ b/DH_P2.53/scripts/app.js
@@ -49,6 +49,30 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const supportsContentVisibility = typeof CSS !== 'undefined'
             && typeof CSS.supports === 'function'
             && CSS.supports('content-visibility', 'auto');
+        const contentVisibilityMediaQuery = typeof window !== 'undefined'
+            && typeof window.matchMedia === 'function'
+            ? window.matchMedia('(max-width: 1019px)')
+            : null;
+
+        function applyRosterContentVisibilityMode() {
+            if (!rosterGrid) return;
+            if (supportsContentVisibility && contentVisibilityMediaQuery?.matches) {
+                rosterGrid.classList.add('roster-cv-enabled');
+            } else {
+                rosterGrid.classList.remove('roster-cv-enabled');
+            }
+        }
+
+        applyRosterContentVisibilityMode();
+
+        if (contentVisibilityMediaQuery) {
+            const handleContentVisibilityChange = () => applyRosterContentVisibilityMode();
+            if (typeof contentVisibilityMediaQuery.addEventListener === 'function') {
+                contentVisibilityMediaQuery.addEventListener('change', handleContentVisibilityChange);
+            } else if (typeof contentVisibilityMediaQuery.addListener === 'function') {
+                contentVisibilityMediaQuery.addListener(handleContentVisibilityChange);
+            }
+        }
 
         const COMPARE_BUTTON_PREVIEW_HTML = '<span class="button-text">Preview</span>';
         const COMPARE_BUTTON_SHOW_ALL_HTML = '<span class="compare-show-all-stack"><i aria-hidden="true" class="fa-solid fa-arrows-left-right-to-line compare-show-all-icon"></i><span class="compare-show-all-label">Show All</span></span>';
@@ -3059,7 +3083,7 @@ const wrTeStatOrder = [
         }
 
         function calibrateTeamCardIntrinsicSize(card) {
-            if (!supportsContentVisibility || !card) return;
+            if (!supportsContentVisibility || !card || !rosterGrid?.classList.contains('roster-cv-enabled')) return;
             requestAnimationFrame(() => {
                 const measuredHeight = card.getBoundingClientRect().height;
                 if (measuredHeight > 0) {
@@ -3069,6 +3093,7 @@ const wrTeStatOrder = [
         }
 
         function renderAllTeamData(teams) {
+            applyRosterContentVisibilityMode();
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
 

--- a/DH_P2.53/styles/styles.css
+++ b/DH_P2.53/styles/styles.css
@@ -37,6 +37,7 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+        --roster-card-blur: 1px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -904,13 +905,11 @@
             gap: 0.25rem;
         }
 
-@media (min-width: 820px) {
-  @supports (content-visibility: auto) {
-    #rosterGrid .team-card {
+@supports (content-visibility: auto) {
+    #rosterGrid.roster-cv-enabled .team-card {
         content-visibility: auto;
         contain-intrinsic-size: auto var(--team-card-intrinsic-size, 1200px);
     }
-  }
 }
 
         .roster-section h3 {
@@ -988,10 +987,21 @@
             flex-direction: column;
             gap: 0.01rem;
             transition: all 0.2s ease;
-            backdrop-filter: blur(1px);
-            -webkit-backdrop-filter: blur(1px);
+            backdrop-filter: blur(var(--roster-card-blur, 1px));
+            -webkit-backdrop-filter: blur(var(--roster-card-blur, 1px));
             box-shadow: 0 0 20px rgba(0,0,0,0.1);
         }
+
+@media (min-width: 1024px) {
+    body[data-page="rosters"] {
+        --roster-card-blur: 0px;
+    }
+
+    body[data-page="rosters"] .player-row,
+    body[data-page="rosters"] .pick-row {
+        contain: paint;
+    }
+}
         .is-trade-mode .player-row, .is-trade-mode .pick-row { 
             cursor: pointer; 
         }


### PR DESCRIPTION
## Summary
- gate team card content-visibility behind a viewport-aware class so desktop renders the full roster immediately
- expose a roster card blur variable and disable the expensive blur on desktop while keeping mobile styling intact
- add paint containment to roster cards to shrink repaint regions during scroll

## Testing
- python3 -m http.server 8000 (manually loaded rosters for the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68e149ca65ec832ea436f9d9bf459bb9